### PR TITLE
feat: add `import/export type` hidden

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,13 @@
   "vitest.enable": true,
   "vitest.include": ["**/*.test.ts"],
   "vitest.exclude": ["**/node_modules/**", "**/dist/**", "**/.history/**"],
-  "vitest.commandLine": "pnpm exec vitest -u --api.host 127.0.0.1"
+  "vitest.commandLine": "pnpm exec vitest -u --api.host 127.0.0.1",
+  "i18n-ally.localesPaths": [],
+  "cSpell.words": [
+    "indexs"
+  ],
+  "editor.tokenColorCustomizations": {
+    "comments": "",
+    "textMateRules": []
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,13 +3,5 @@
   "vitest.enable": true,
   "vitest.include": ["**/*.test.ts"],
   "vitest.exclude": ["**/node_modules/**", "**/dist/**", "**/.history/**"],
-  "vitest.commandLine": "pnpm exec vitest -u --api.host 127.0.0.1",
-  "i18n-ally.localesPaths": [],
-  "cSpell.words": [
-    "indexs"
-  ],
-  "editor.tokenColorCustomizations": {
-    "comments": "",
-    "textMateRules": []
-  }
+  "vitest.commandLine": "pnpm exec vitest -u --api.host 127.0.0.1"
 }

--- a/README.md
+++ b/README.md
@@ -152,6 +152,37 @@ English | [简体中文](./README.zh.md)
     declare module 'g' {}
     ```
     ⏭️ 👆All statements that begin with `declare`
+  
+  - `type-only-import-declaration`:
+    ```ts
+    import type * as a from 'a';
+    import type { b1 } from 'b';
+    ```
+    ⏭️  `import type * as a from 'a';`
+
+    ⏭️  `import type { b1 } from 'b';`
+
+  - `import-type-specifier`:
+    ```ts
+    import {type a1, a2} from 'a';
+    ```
+    ⏭️  `type a1`
+  
+  - `type-only-export-declaration`:
+    ```ts
+    export type * as a from 'a';
+    export type { b1 } from 'b';
+    ```
+    ⏭️  `export type * from 'a';`
+
+    ⏭️  `export type { b1 } from 'b';`
+
+  - `export-type-specifier`:
+    ```ts
+    export {a1, type a2} from 'a';
+    ```
+    ⏭️  ` type a2`
+
   </details>
 
 ## CHANGELOG

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "vscode": "^1.70.0",
     "node": ">=17.0.0"
   },
-  "packageManager": ">=pnpm@8.5.0",
+  "packageManager": "pnpm@8.15.0",
   "activationEvents": [
     "onStartupFinished"
   ],
@@ -78,7 +78,11 @@
               "as-assertion",
               "satisfies-operator",
               "declare-statement",
-              "variable-type-definition"
+              "variable-type-definition",
+              "type-only-import-declaration",
+              "import-specifier-declaration",
+              "type-only-export-declaration",
+              "export-specifier-declaration"
             ],
             "markdownEnumDescriptions": [
               "```ts \ntype A  = ({ ... } & { ... }) | string[] \n```\n ⏭️  `type A = ({ ... } & { ... }) | string[]`",
@@ -95,7 +99,13 @@
               "```ts \nfn() as any;\n``` \n ⏭️  ` as any`",
               "```ts \nconst user = { ... } satisfies UserModel;\n``` \n ⏭️  ` satisfies UserModel`",
               "```ts \ndeclare const a: number;\ndeclare function b(): number;\ndeclare class c {}\ndeclare module d {}\ndeclare namespace e {}\ndeclare enum f {}\ndeclare global {}\ndeclare module 'g' {}\n``` \n ⏭️ 👆 All statements that begin with `declare`",
-              "```ts \nconst a: number = 1;\n``` \n ⏭️  `: number`"
+              "```ts \nconst a: number = 1;\n``` \n ⏭️  `: number`",
+              "```ts \nimport type { ... } from 'a';\n``` \n ⏭️  `import type { ... } from 'a';`",
+              "```ts \nimport type * as a from 'a';\n``` \n ⏭️  `import type * as a from 'a';`",
+              "```ts \nimport {type a1} from 'a';\n``` \n ⏭️  `type a1`",
+              "```ts \nexport type { ... } from 'b';\n``` \n ⏭️  `export type { ... } from 'b';`",
+              "```ts \nexport type * from 'b';\n``` \n ⏭️  `export type * from 'b';`",
+              "```ts \nexport {type b1} from 'b';\n``` \n ⏭️  `type b1`"
             ]
           },
           "description": "Type kind to ignore when hiding"
@@ -115,6 +125,7 @@
     "build": "run-s type-check test && tsup",
     "dev": "tsup --watch src",
     "test": "vitest run",
+    "test:ui": "vitest --ui",
     "type-check": "tsc",
     "vsce-package": "run-s build && tsx scripts/vsce-package",
     "vsce-publish": "run-s build && tsx scripts/vsce-package --publish"
@@ -125,7 +136,9 @@
     "@types/lodash-es": "^4.17.7",
     "@types/mocha": "^10.0.1",
     "@types/vscode": "^1.70.0",
+    "@vitest/ui": "^1.4.0",
     "@vscode/test-electron": "^2.3.0",
+    "@vscode/vsce": "^2.24.0",
     "execa": "^7.1.1",
     "fs-extra": "^11.1.1",
     "glob": "^8.1.0",
@@ -138,7 +151,7 @@
     "type-fest": "^3.8.0",
     "typescript": "^5.2.2",
     "vite": "^4.3.1",
-    "vitest": "^0.28.4",
+    "vitest": "^1.4.0",
     "vsce": "^2.15.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "build": "run-s type-check test && tsup",
     "dev": "tsup --watch src",
     "test": "vitest run",
-    "test:ui": "vitest --ui",
     "type-check": "tsc",
     "vsce-package": "run-s build && tsx scripts/vsce-package",
     "vsce-publish": "run-s build && tsx scripts/vsce-package --publish"
@@ -136,9 +135,7 @@
     "@types/lodash-es": "^4.17.7",
     "@types/mocha": "^10.0.1",
     "@types/vscode": "^1.70.0",
-    "@vitest/ui": "^1.4.0",
     "@vscode/test-electron": "^2.3.0",
-    "@vscode/vsce": "^2.24.0",
     "execa": "^7.1.1",
     "fs-extra": "^11.1.1",
     "glob": "^8.1.0",
@@ -151,7 +148,7 @@
     "type-fest": "^3.8.0",
     "typescript": "^5.2.2",
     "vite": "^4.3.1",
-    "vitest": "^1.4.0",
+    "vitest": "^0.28.4",
     "vsce": "^2.15.0"
   }
 }

--- a/src/core/helpers/type-analyzer/constants.ts
+++ b/src/core/helpers/type-analyzer/constants.ts
@@ -133,5 +133,35 @@ export enum TYPE_KIND {
    * ```
    * ⏭️  👆 All statements that begin with `declare`
    */
-  DECLARE_STATEMENT = 'declare-statement'
+  DECLARE_STATEMENT = 'declare-statement',
+  /**
+   * ```ts
+   * import type { a1 } from 'a';
+   * import type * as b1 from 'b';
+   * ```
+   * ⏭️  `import type ...;`
+   */
+  IMPORT_TYPE_DECLARATION = 'import-type-declaration',
+  /**
+   * ```ts`
+   * import { type c1, c2 } from 'c'; 
+   * ```
+   * ⏭️  `type c`
+   */
+  IMPORT_TYPE_SPECIFIER = 'import-type-specifier',
+   /**
+   * ```ts
+   * export type { a } from 'a';
+   * export type * from 'b';
+   * ```
+   * ⏭️  `export type ...;`
+   */
+  EXPORT_TYPE_DECLARATION = 'export-type-declaration',
+  /**
+   * ```ts
+   * export { type c1, c2 } from 'c'; 
+   * ```
+   * ⏭️  `type c1`
+   */
+  EXPORT_TYPE_SPECIFIER = 'export-type-specifier'
 }

--- a/src/core/helpers/type-analyzer/constants.ts
+++ b/src/core/helpers/type-analyzer/constants.ts
@@ -141,7 +141,7 @@ export enum TYPE_KIND {
    * ```
    * ⏭️  `import type ...;`
    */
-  IMPORT_TYPE_DECLARATION = 'import-type-declaration',
+  TYPE_ONLY_IMPORT_DECLARATION = 'type-only-import-declaration',
   /**
    * ```ts`
    * import { type c1, c2 } from 'c'; 
@@ -156,7 +156,7 @@ export enum TYPE_KIND {
    * ```
    * ⏭️  `export type ...;`
    */
-  EXPORT_TYPE_DECLARATION = 'export-type-declaration',
+  TYPE_ONLY_EXPORT_DECLARATION = 'type-only-export-declaration',
   /**
    * ```ts
    * export { type c1, c2 } from 'c'; 

--- a/src/core/helpers/type-analyzer/index.test.ts
+++ b/src/core/helpers/type-analyzer/index.test.ts
@@ -795,12 +795,12 @@ import type {b1, b2} from "b"
       {
         range: { pos: 1, end: 28 },
         text: 'import type * as a from "a"',
-        kind: TYPE_KIND.IMPORT_TYPE_DECLARATION
+        kind: TYPE_KIND.TYPE_ONLY_IMPORT_DECLARATION
       },
       {
         range: { pos: 29, end: 58 },
         text: 'import type {b1, b2} from "b"',
-        kind: TYPE_KIND.IMPORT_TYPE_DECLARATION
+        kind: TYPE_KIND.TYPE_ONLY_IMPORT_DECLARATION
       }
     ]);
   });
@@ -876,12 +876,12 @@ export type * as c1 from "c"
       {
         range: { pos: 1, end: 23 },
         text: 'export type * from "a"',
-        kind: TYPE_KIND.EXPORT_TYPE_DECLARATION
+        kind: TYPE_KIND.TYPE_ONLY_EXPORT_DECLARATION
       },
       {
         range: { pos: 24, end: 52 },
         text: 'export type * as c1 from "c"',
-        kind: TYPE_KIND.EXPORT_TYPE_DECLARATION
+        kind: TYPE_KIND.TYPE_ONLY_EXPORT_DECLARATION
       }
     ]);
   });
@@ -897,7 +897,7 @@ export type {b1,b2} from "b"`,
       {
         range: { pos: 1, end: 29 },
         text: 'export type {b1,b2} from "b"',
-        kind: TYPE_KIND.EXPORT_TYPE_DECLARATION
+        kind: TYPE_KIND.TYPE_ONLY_EXPORT_DECLARATION
       }
     ]);
   });

--- a/src/core/helpers/type-analyzer/index.test.ts
+++ b/src/core/helpers/type-analyzer/index.test.ts
@@ -777,3 +777,154 @@ describe('tsx', () => {
     ]);
   });
 });
+
+describe('import', () => {
+  it('import type ...', () => {
+    const analyzer = new TypeAnalyzer(
+      `
+import type * as a from "a"
+import type {b1, b2} from "b"
+// NO import type * from "b"
+`,
+      true
+    );
+    analyzer.analyze();
+
+    expect(analyzer.analyzedTypes).toMatchObject([
+      // KEY: ImportClause.isTypeOnly = true
+      {
+        range: { pos: 1, end: 28 },
+        text: 'import type * as a from "a"',
+        kind: TYPE_KIND.IMPORT_TYPE_DECLARATION
+      },
+      {
+        range: { pos: 29, end: 58 },
+        text: 'import type {b1, b2} from "b"',
+        kind: TYPE_KIND.IMPORT_TYPE_DECLARATION
+      }
+    ]);
+  });
+  it('import {type ...} ...', () => {
+    const analyzer = new TypeAnalyzer(
+      `
+import {type c1, c2} from "c"
+import {type d1, type d2} from "d"
+`,
+      true
+    );
+    analyzer.analyze();
+    expect(analyzer.analyzedTypes).toMatchObject([
+      {
+        range: { pos: 9, end: 16 },
+        text: 'type c1',
+        kind: TYPE_KIND.IMPORT_TYPE_SPECIFIER
+      },
+      {
+        range: { pos: 39, end: 46 },
+        text: 'type d1',
+        kind: TYPE_KIND.IMPORT_TYPE_SPECIFIER
+      },
+      {
+        range: { pos: 47, end: 55 },
+        text: ' type d2',
+        kind: TYPE_KIND.IMPORT_TYPE_SPECIFIER
+      }
+    ]);
+  });
+  it('import {type ...} plus', () => {
+    const analyzer = new TypeAnalyzer(
+      `
+import {e1, type e2} from "e"
+import {type f1, f2, type f3} from "f"
+`,
+      true
+    );
+    analyzer.analyze();
+    expect(analyzer.analyzedTypes).toMatchObject([
+      {
+        range: { pos: 12, end: 20 },
+        text: ' type e2',
+        kind: TYPE_KIND.IMPORT_TYPE_SPECIFIER
+      },
+      {
+        range: { pos: 39, end: 46 },
+        text: 'type f1',
+        kind: TYPE_KIND.IMPORT_TYPE_SPECIFIER
+      },
+      {
+        range: { pos: 51, end: 59 },
+        text: ' type f3',
+        kind: TYPE_KIND.IMPORT_TYPE_SPECIFIER
+      }
+    ]);
+  });
+});
+
+
+describe('export', () => {
+  it('export type *', () => {
+    const analyzer = new TypeAnalyzer(
+      `
+export type * from "a"
+export type * as c1 from "c"
+`,
+      true
+    );
+    analyzer.analyze();
+
+    expect(analyzer.analyzedTypes).toMatchObject([
+      {
+        range: { pos: 1, end: 23 },
+        text: 'export type * from "a"',
+        kind: TYPE_KIND.EXPORT_TYPE_DECLARATION
+      },
+      {
+        range: { pos: 24, end: 52 },
+        text: 'export type * as c1 from "c"',
+        kind: TYPE_KIND.EXPORT_TYPE_DECLARATION
+      }
+    ]);
+  });
+  it('export type {...}', () => {
+    const analyzer = new TypeAnalyzer(
+      `
+export type {b1,b2} from "b"`,
+      true
+    );
+    analyzer.analyze();
+
+    expect(analyzer.analyzedTypes).toMatchObject([
+      {
+        range: { pos: 1, end: 29 },
+        text: 'export type {b1,b2} from "b"',
+        kind: TYPE_KIND.EXPORT_TYPE_DECLARATION
+      }
+    ]);
+  });
+  it('export {type...} ...', () => {
+    const analyzer = new TypeAnalyzer(
+      `
+export {type c1, c2} from "c"
+export {type d1, type d2} from "d"`,
+      true
+    );
+    analyzer.analyze();
+    expect(analyzer.analyzedTypes).toMatchObject([
+      {
+        range: { pos: 9, end: 16 },
+        text: 'type c1',
+        kind: TYPE_KIND.EXPORT_TYPE_SPECIFIER
+      },
+      {
+        range: { pos: 39, end: 46 },
+        text: 'type d1',
+        kind: TYPE_KIND.EXPORT_TYPE_SPECIFIER
+      },
+      {
+        range: { pos: 47, end: 55 },
+        text: ' type d2',
+        kind: TYPE_KIND.EXPORT_TYPE_SPECIFIER
+      }
+    ]);
+  });
+});

--- a/src/core/helpers/type-analyzer/index.ts
+++ b/src/core/helpers/type-analyzer/index.ts
@@ -426,14 +426,14 @@ export class TypeAnalyzer {
       curChild: ts.ImportDeclaration | ts.ExportDeclaration
     ) {
       if (curChild.kind === ts.SyntaxKind.ImportDeclaration) {
-        return this.pushAnalyzedType(TYPE_KIND.IMPORT_TYPE_DECLARATION, [
+        return this.pushAnalyzedType(TYPE_KIND.TYPE_ONLY_IMPORT_DECLARATION, [
           curChild.pos,
           curChild.end
         ]);
       } else {
         // export type *
         if (curChild?.isTypeOnly) {
-          return this.pushAnalyzedType(TYPE_KIND.EXPORT_TYPE_DECLARATION, [
+          return this.pushAnalyzedType(TYPE_KIND.TYPE_ONLY_EXPORT_DECLARATION, [
             curChild.pos,
             curChild.end
           ]);

--- a/src/core/helpers/type-analyzer/index.ts
+++ b/src/core/helpers/type-analyzer/index.ts
@@ -88,7 +88,9 @@ export class TypeAnalyzer {
       ts.isVariableStatement(node) ||
       ts.isClassDeclaration(node) ||
       ts.isModuleDeclaration(node) ||
-      ts.isEnumDeclaration(node)
+      ts.isEnumDeclaration(node) ||
+      ts.isTypeOnlyImportOrExportDeclaration(node) ||
+      ts.isExportDeclaration(node)
     ) {
       if (parent) {
         this.handleDifferentNode(parent!, node);
@@ -116,7 +118,8 @@ export class TypeAnalyzer {
       [ts.SyntaxKind.CallExpression]: handleParentCallOrNewExpr.bind(this),
       [ts.SyntaxKind.NewExpression]: handleParentCallOrNewExpr.bind(this),
       [ts.SyntaxKind.PropertyDeclaration]: handleParentPropertyDeclaration.bind(this),
-      [ts.SyntaxKind.JsxSelfClosingElement]: handleParentJsxElement.bind(this)
+      [ts.SyntaxKind.JsxSelfClosingElement]: handleParentJsxElement.bind(this),
+      [ts.SyntaxKind.ImportDeclaration]: handleParentImportOrExportDeclaration.bind(this) // import type
     };
 
     const childNodeHandlers: NodeHandlers = {
@@ -127,7 +130,10 @@ export class TypeAnalyzer {
       [ts.SyntaxKind.ModuleDeclaration]: handleChildDeclareStatement.bind(this),
       [ts.SyntaxKind.EnumDeclaration]: handleChildDeclareStatement.bind(this),
       [ts.SyntaxKind.GetAccessor]: handleChildGetOrSetAccessor.bind(this),
-      [ts.SyntaxKind.SetAccessor]: handleChildGetOrSetAccessor.bind(this)
+      [ts.SyntaxKind.SetAccessor]: handleChildGetOrSetAccessor.bind(this),
+      [ts.SyntaxKind.ImportSpecifier]: handleImportOrExportSpecifier.bind(this), // import {type}
+      [ts.SyntaxKind.ExportSpecifier]: handleImportOrExportSpecifier.bind(this), // export {type}
+      [ts.SyntaxKind.ExportDeclaration]: handleParentImportOrExportDeclaration.bind(this) // export type {}
     };
 
     parentNodeHandlers[parent.kind]?.(parent, child);
@@ -159,7 +165,6 @@ export class TypeAnalyzer {
         ]);
       }
     }
-
     // [class] context: `class A { a?: number }`, get `?: number`
     function handleParentPropertyDeclaration(
       this: TypeAnalyzer,
@@ -412,6 +417,44 @@ export class TypeAnalyzer {
           curChild.end
         ]);
       }
+    }
+
+    // `import/export type ...;` get `import/export type ...;`
+    // especial:` export {a, type b}` get ` type b`
+    function handleParentImportOrExportDeclaration(
+      this: TypeAnalyzer,
+      curChild: ts.ImportDeclaration | ts.ExportDeclaration
+    ) {
+      if (curChild.kind === ts.SyntaxKind.ImportDeclaration) {
+        return this.pushAnalyzedType(TYPE_KIND.IMPORT_TYPE_DECLARATION, [
+          curChild.pos,
+          curChild.end
+        ]);
+      } else {
+        // export type *
+        if (curChild?.isTypeOnly) {
+          return this.pushAnalyzedType(TYPE_KIND.EXPORT_TYPE_DECLARATION, [
+            curChild.pos,
+            curChild.end
+          ]);
+        }
+        // export {type}
+        else {
+          ts.forEachChild(curChild, _child => this.visit(_child, curChild));
+        }
+      }
+    }
+    // context = `import {a1, type a2} from "a"` get `type a2`
+    function handleImportOrExportSpecifier(
+      this: TypeAnalyzer,
+      curChild: ts.ImportSpecifier | ts.ExportSpecifier
+    ) {
+      // TODO: offset
+      const mappingKind = {
+        [ts.SyntaxKind.ImportSpecifier]: TYPE_KIND.IMPORT_TYPE_SPECIFIER,
+        [ts.SyntaxKind.ExportSpecifier]: TYPE_KIND.EXPORT_TYPE_SPECIFIER
+      };
+      this.pushAnalyzedType(mappingKind[curChild.kind], [curChild.pos, curChild.end]);
     }
   }
 


### PR DESCRIPTION
Add hidden rules at import/export type
```ts
// import
import type * as a from 'a'
import {type b} from 'b'

// export
export type * from 'a'
export {type b} from 'b'
```
